### PR TITLE
Enable sendmail without modifying code.

### DIFF
--- a/modules/Emails/mail.php
+++ b/modules/Emails/mail.php
@@ -268,6 +268,12 @@ function setMailServerProperties($mail)
 		$server = $_REQUEST['server'];
 	else
 		$server = $adb->query_result($res,0,'server');
+		
+	if(!empty($server) || $server=="sendmail"){
+		$mail->IsSendmail();
+		return;
+	}
+	
 	if(isset($_REQUEST['server_username']))
 		$username = $_REQUEST['server_username'];
 	else


### PR DESCRIPTION
For example one of our server have policy to block outgoing smtp from web server, the only way you can send mail is thru sendmail.

With this simple patch, you can type "sendmail" in server field, and mails/notification will go thru sendmail with a proper headers, you don't need to create mail accounts and other stuff :)

Test case from net:
https://discussions.vtiger.com/index.php?p=/discussion/169387/outgoing-email-imposible-to-get-it-working/p1
https://discussions.vtiger.com/index.php?p=/discussion/53944/smtp-outgoing-server-issues/p1
